### PR TITLE
Add localhost url for dev server

### DIFF
--- a/scripts/dev.js
+++ b/scripts/dev.js
@@ -9,5 +9,5 @@ const port = config.devPort ?? 8080;
 app.use("/", express.static("dist"));
 
 app.listen(port, () => {
-  console.log(`Site is listening on port: ${port}`);
+  console.log(`Dev site running at: http://localhost:${port}/`);
 });


### PR DESCRIPTION
Adds the localhost URL as well as the port to the console message URL to make life easy for accessing the dev website as many terminals (including x-terminal-reloaded) make this a clickable link. This is just the laziest possible way of doing it but something I'm used to from the vuepress site - feel free to implement better if needed :)