### PR TITLE
Fix codeblock in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,13 +292,13 @@ Code tabs plugin.
 
 ```markdown
 
-```js [g1:JavaScript]
+~~~js [g1:JavaScript]
 console.log("hello");
-```
+~~~
 
-```py [g1:Python3]
+~~~py [g1:Python3]
 print("hello")
-```
+~~~
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -290,17 +290,17 @@ Mirrored from `markdown-it-ins` supports the `<del>` element.
 
 Code tabs plugin.
 
-```markdown
+~~~markdown
 
-~~~js [g1:JavaScript]
+```js [g1:JavaScript]
 console.log("hello");
-~~~
-
-~~~py [g1:Python3]
-print("hello")
-~~~
-
 ```
+
+```py [g1:Python3]
+print("hello")
+```
+
+~~~
 
 ## `markdown-it-footnote`
 

--- a/README.md
+++ b/README.md
@@ -290,7 +290,7 @@ Mirrored from `markdown-it-ins` supports the `<del>` element.
 
 Code tabs plugin.
 
-~~~markdown
+````markdown
 
 ```js [g1:JavaScript]
 console.log("hello");
@@ -300,7 +300,7 @@ console.log("hello");
 print("hello")
 ```
 
-~~~
+````
 
 ## `markdown-it-footnote`
 


### PR DESCRIPTION
Fixes the readme codeblock as it was overflowing. Just adds an extra backtick to the surrounding block. (You can also do it with tildes but thought this was neater).