### PR TITLE
Add task list support

### DIFF
--- a/README.md
+++ b/README.md
@@ -322,3 +322,19 @@ Here is a footnote reference,[^1] and another.[^longnote]
   footnote.
 
 ```
+
+## `markdown-it-task-lists`
+
+* [NPM](https://www.npmjs.com/package/markdown-it-task-lists)
+* [GitHub](https://github.com/revin/markdown-it-task-lists)
+
+Adds tasklist support as per the [GFM extension](https://github.github.com/gfm/#task-list-items-extension-)
+
+```markdown
+
+- [x] foo
+  - [ ] bar
+  - [x] baz
+- [ ] bim
+
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "markdown-it-named-code-blocks": "^0.1.0",
         "markdown-it-sub": "^1.0.0",
         "markdown-it-sup": "^1.0.0",
+        "markdown-it-task-lists": "^2.1.1",
         "minify": "^9.2.0",
         "sass": "^1.60.0",
         "terser": "^5.16.8"
@@ -1738,6 +1739,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/markdown-it-sup/-/markdown-it-sup-1.0.0.tgz",
       "integrity": "sha512-E32m0nV9iyhRR7CrhnzL5msqic7rL1juWre6TQNxsnApg7Uf+F97JOKxUijg5YwXz86lZ0mqfOnutoryyNdntQ=="
+    },
+    "node_modules/markdown-it-task-lists": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/markdown-it-task-lists/-/markdown-it-task-lists-2.1.1.tgz",
+      "integrity": "sha512-TxFAc76Jnhb2OUu+n3yz9RMu4CwGfaT788br6HhEDlvWfdeJcLUsxk1Hgw2yJio0OXsxv7pyIPmvECY7bMbluA=="
     },
     "node_modules/mdurl": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "markdown-it-named-code-blocks": "^0.1.0",
     "markdown-it-sub": "^1.0.0",
     "markdown-it-sup": "^1.0.0",
+    "markdown-it-task-lists": "^2.1.1",
     "minify": "^9.2.0",
     "sass": "^1.60.0",
     "terser": "^5.16.8"

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -41,6 +41,7 @@ const md = require("../site.config.js").md ?? new MarkdownIt({
 }).use(require("markdown-it-fontawesome") // font awesome support
 ).use(require("markdown-it-codetabs") // Codetabs support
 ).use(require("markdown-it-footnote") // Footnote support
+).use(require("markdown-it-task-lists") // Task list support
 ).use(require("./markdown-it-del.js") // del support
 ).use(require("./markdown-it-include-ejs.js"), { // allows including EJS docs
   root: "./"


### PR DESCRIPTION
Adds tasklist support as per the [GFM extension](https://github.github.com/gfm/#task-list-items-extension-)

* [NPM](https://www.npmjs.com/package/markdown-it-task-lists)
* [GitHub](https://github.com/revin/markdown-it-task-lists)

```markdown

- [x] foo
  - [ ] bar
  - [x] baz
- [ ] bim

```